### PR TITLE
Fix: 사용자 프로필 ‘대학8학기이상’으로 수정

### DIFF
--- a/musccat-project-fe/src/component/page/MemInfo.jsx
+++ b/musccat-project-fe/src/component/page/MemInfo.jsx
@@ -407,7 +407,7 @@ const MemInfo = () => {
 
     const semesterCategoryOptions = [
         { value: '대학신입생', label: '대학신입생' },
-        ...Array.from({ length: 7 }, (_, i) => ({ value: `대학${i + 2}학기`, label: `대학${i + 2}학기` })),
+        ...Array.from({ length: 6 }, (_, i) => ({ value: `대학${i + 2}학기`, label: `대학${i + 2}학기` })),
         { value: '대학8학기이상', label: '대학8학기이상' }
     ];
 


### PR DESCRIPTION
사용자 프로필 수료 학기 입력 항목 중 '대학8학기'를 삭제하고 '대학8학기이상'으로 수정